### PR TITLE
添加对JSON格式配置文件以及读取外部JSON配置文件的支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ nouse.py
 
 .DS_Store
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -74,17 +74,29 @@ server {
 
 提示：从 1.0 迁移请注意修改 bot\_constant.py
 
-请在bot使用之前，将bot_constant-sample.py重命名为bot_constant.py
+请在bot使用之前，将`bot_constant-sample.py`重命名为`bot_constant.py`
 
-键   | 值
-:--- | ---
-`TOKEN` | Telegram机器人的token
-`QQ_BOT_ID` | QQ机器人的QQ号
-`FORWARD_LIST` | 一个list，可以定义多个转发关系，list中的每一个dict [QQ群的群号, Telegram群的群I，开车模式默认值, 图片链接模式默认值]都代表一个转发关系。仅支持QQ群和Telegram群一一对应的关系。
-`SERVER_PIC_URL` | 图片访问的url前缀。
-`CQ_ROOT_DIR` | 酷Q的根目录路径
-`CQ_PORT` | 酷Q Socket API 数据监听端口
-`JQ_MODE` | 交钱模式。如果使用酷Q Pro，请设置为True，如果使用酷Q Air，请设置为False。
+键               | 值
+:--------------- | ---
+`TOKEN`          | Telegram机器人的token
+`QQ_BOT_ID`      | QQ机器人的QQ号
+`FORWARD_LIST`   | 一个list，可以定义多个转发关系，list中的每一个dict [QQ群的群号, Telegram群的群I，开车模式默认值, 图片链接模式默认值]都代表一个转发关系。仅支持QQ群和Telegram群一一对应的关系。
+`SERVER_PIC_URL` | 图片访问的url前缀
+`CQ_ROOT_DIR`    | 酷Q的根目录路径
+`CQ_PORT`        | 酷Q Socket API 数据监听端口
+`JQ_MODE`        | 交钱模式。如果使用酷Q Pro，请设置为True，如果使用酷Q Air，请设置为False。
+
+### bot_constant.json
+键值对的对应关系与bot_constant.py相同。
+
+如要使用JSON格式的配置文件，请将`bot_constant-json.py`重命名为`bot_constant.py`以启用JSON配置文件支持特性。
+
+如要加载外部配置文件，请将外部配置文件的路径添加至环境变量 `CTB_JSON_SETTINGS_PATH`
+例：
+
+```shell
+$ export CTB_JSON_SETTINGS_PATH="/home/user/bot_constant.json"
+```
 
 ### qq_emoji_list.py
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ server {
 ```shell
 $ export CTB_JSON_SETTINGS_PATH="/home/user/bot_constant.json"
 ```
+`tools/bot_constant-py2json.py`提供了将`bot_constant.py`转换为`bot_constant.json`的工具
 
 ### qq_emoji_list.py
 

--- a/README.md
+++ b/README.md
@@ -76,19 +76,15 @@ server {
 
 请在bot使用之前，将bot_constant-sample.py重命名为bot_constant.py
 
-TOKEN：Telegram机器人的token
-
-QQ_BOT_ID：QQ机器人的QQ号
-
-FORWARD\_LIST：一个list，可以定义多个转发关系，list中的每一个dict [QQ群的群号, Telegram群的群I，开车模式默认值, 图片链接模式默认值]都代表一个转发关系。仅支持QQ群和Telegram群一一对应的关系。
-
-SERVER\_PIC\_URL：图片访问的url前缀。
-
-CQ\_ROOT\_DIR：酷Q的根目录路径
-
-CQ\_PORT：酷Q Socket API 数据监听端口
-
-JQ\_MODE：交钱模式。如果使用酷Q Pro，请设置为True，如果使用酷Q Air，请设置为False。
+键   | 值
+:--- | ---
+`TOKEN` | Telegram机器人的token
+`QQ_BOT_ID` | QQ机器人的QQ号
+`FORWARD_LIST` | 一个list，可以定义多个转发关系，list中的每一个dict [QQ群的群号, Telegram群的群I，开车模式默认值, 图片链接模式默认值]都代表一个转发关系。仅支持QQ群和Telegram群一一对应的关系。
+`SERVER_PIC_URL` | 图片访问的url前缀。
+`CQ_ROOT_DIR` | 酷Q的根目录路径
+`CQ_PORT` | 酷Q Socket API 数据监听端口
+`JQ_MODE` | 交钱模式。如果使用酷Q Pro，请设置为True，如果使用酷Q Air，请设置为False。
 
 ### qq_emoji_list.py
 

--- a/bot_constant-json.py
+++ b/bot_constant-json.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+将本文件重名为为 bot_constant.py 以启用JSON格式配置文件支持。
+本脚本支持读取外部配置文件,默认读取bot_constant.json
+
+请将外部配置文件的路径添加至环境变量 CTB_JSON_SETTINGS_PATH
+例如：/home/user/bot_constant.json 或 ../esuSet.json
+"""
+
+import os
+import json
+
+filepath = os.getenv('CTB_JSON_SETTINGS_PATH', 'bot_constant.json')
+with open(filepath, 'r') as f1:
+    settingsJSON = json.loads(f1.read())
+
+TOKEN = settingsJSON['TOKEN']
+QQ_BOT_ID = settingsJSON['QQ_BOT_ID']
+FORWARD_LIST = settingsJSON['FORWARD_LIST']
+SERVER_PIC_URL = settingsJSON['SERVER_PIC_URL']
+CQ_ROOT = settingsJSON['CQ_ROOT']
+CQ_PORT = settingsJSON['CQ_PORT']
+JQ_MODE = settingsJSON['JQ_MODE']  # if use Coolq Pro, set as True, otherwise False
+print('[CTBot] JSON Config file support [EN]')

--- a/bot_constant-sample.json
+++ b/bot_constant-sample.json
@@ -1,0 +1,22 @@
+{
+    "TOKEN": "your telegram bot token",
+    "QQ_BOT_ID": 1111111111,
+    "FORWARD_LIST": [
+        {
+            "QQ": 12345678,
+            "TG": -23456789,
+            "Drive_mode": false,
+            "Pic_link": true
+        },
+        {
+            "QQ": 87654321,
+            "TG": -76543218,
+            "Drive_mode": false,
+            "Pic_link": true
+        }
+    ],
+    "SERVER_PIC_URL": "http://example.com:8080/image/",
+    "CQ_ROOT": "/home/coolq/coolq_pro/",
+    "CQ_PORT": 11235,
+    "JQ_MODE": true
+}

--- a/tools/bot_constant-py2json.py
+++ b/tools/bot_constant-py2json.py
@@ -1,0 +1,43 @@
+"""
+该脚本可将配置文件bot_constant.py转换为bot_constant.json并保存在当前目录下。
+
+[Useage]
+python3 bot_constant-py2json.py [-i *.py file]
+    -i 指定输入文件，如不指定则默认为../bot_constant.py
+"""
+
+import sys
+import json
+import os.path
+
+
+def py2json():
+    r = {}
+    r.setdefault("TOKEN", TOKEN)
+    r.setdefault('QQ_BOT_ID', QQ_BOT_ID)
+    r.setdefault('FORWARD_LIST', FORWARD_LIST)
+    r.setdefault('SERVER_PIC_URL', SERVER_PIC_URL)
+    r.setdefault('CQ_ROOT', CQ_ROOT)
+    r.setdefault('CQ_PORT', CQ_PORT)
+    r.setdefault('JQ_MODE', JQ_MODE)
+    jData = json.dumps(r, indent=4)
+    print(jData)
+    return jData
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 3 and sys.argv[1] == '-i':
+        filepath1 = sys.argv[2]
+        with open(filepath1, mode='r') as f1:
+            ex = f1.read()
+        exec(ex)
+    elif len(sys.argv) == 1:
+        with open(os.path.abspath('../bot_constant.py'), mode='r') as f1:
+            ex = f1.read()
+        exec(ex)
+    else:
+        print(__doc__)
+        exit(1)
+    with open('bot_constant.json','x') as fo:
+        fo.write(py2json())
+


### PR DESCRIPTION
为什么要读取外部配置文件？
1. 如果将bot至于容器内，在容器内修改配置文件较麻烦。
2. 增强bot部署灵活性

为什么要使用JSON格式？
1. https://www.json.cn/wiki.html
2. JSON文件相对于py文件，可以更灵活的解析而无需考虑变量作用域问题。

为什么要采用修改`bot_constant.py`的方式？

至少6个文件引用了`from bot_constant import [something]`，使得`bot_constant.py`本身成为了多个源码的依赖，不如直接将其改造为配置文件的载入入口。
![巨大变量多引用](https://i.loli.net/2017/11/11/5a06abffb51a4.png)