### PR TITLE
等待 HTTP API 准备就绪而不是直接 exit

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -87,11 +87,14 @@ class MainProcess(Daemon):
             daemon=True)
         threaded_server.start()
 
-        try:
-            bot_status = qq_bot.get_status()
-        except Exception as e:
-            logger.error('Could not reach Coolq-http-api, please check Coolq plugins.')
-            exit(-1)
+        should_wait = true
+        while should_wait:
+            try:
+                bot_status = qq_bot.get_status()
+                should_wait = False
+            except Exception as e:
+                logger.warning('Could not reach Coolq-http-api, keep waiting...')
+                time.sleep(0.5)
         logger.debug('Coolq-http-api status: ok')
 
         import plugins  # load all plugins

--- a/daemon.py
+++ b/daemon.py
@@ -87,7 +87,7 @@ class MainProcess(Daemon):
             daemon=True)
         threaded_server.start()
 
-        should_wait = true
+        should_wait = True
         while should_wait:
             try:
                 bot_status = qq_bot.get_status()

--- a/daemon.py
+++ b/daemon.py
@@ -94,7 +94,7 @@ class MainProcess(Daemon):
                 should_wait = False
             except Exception as e:
                 logger.warning('Could not reach Coolq-http-api, keep waiting...')
-                time.sleep(0.5)
+                time.sleep(1)
         logger.debug('Coolq-http-api status: ok')
 
         import plugins  # load all plugins

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,5 @@ Pillow==4.3.0
 pycurl==7.43.0
 python-telegram-bot==9.0.0
 requests==2.18.4
-unattended-upgrades==0.1
 urllib3==1.22
 coloredlogs==7.3.1
-


### PR DESCRIPTION
我写了个把 ctb 单独运行的 docker 镜像：

```dockerfile
FROM python:3.6

RUN git clone https://github.com/richardchien/coolq-telegram-bot.git app

WORKDIR app
RUN sed -i "/^unattended-upgrades.*/d" requirements.txt \
    && pip install -r requirements.txt

CMD ["python", "daemon.py", "run"]
```

这样的话，在使用 docker-compose 同时启动酷 Q 容器和 ctb 容器的时候，ctb 就直接 exit，感觉应该改成等待比较好